### PR TITLE
物理世界分離と技

### DIFF
--- a/Game/KANJI/KANJI.xcodeproj/project.pbxproj
+++ b/Game/KANJI/KANJI.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		72A3BDFC255175C8003393C4 /* BattleUIManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72A3BDFA255175C8003393C4 /* BattleUIManager.cpp */; };
 		72DB89942568D97000BF7CC5 /* HolderUI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89922568D97000BF7CC5 /* HolderUI.cpp */; };
 		72DB899A2568F13D00BF7CC5 /* PhysicalWorldManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89982568F13D00BF7CC5 /* PhysicalWorldManager.cpp */; };
+		72DB89A1256916B200BF7CC5 /* PhysicalStage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB899E256916B100BF7CC5 /* PhysicalStage.cpp */; };
+		72DB89A2256916B200BF7CC5 /* PhysicalCharacter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89A0256916B100BF7CC5 /* PhysicalCharacter.cpp */; };
 		C800DE80253DE01900C3835B /* CharacterSelectionScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C800DE7E253DE01800C3835B /* CharacterSelectionScene.cpp */; };
 /* End PBXBuildFile section */
 
@@ -219,6 +221,10 @@
 		72DB89932568D97000BF7CC5 /* HolderUI.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = HolderUI.hpp; sourceTree = "<group>"; };
 		72DB89982568F13D00BF7CC5 /* PhysicalWorldManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PhysicalWorldManager.cpp; sourceTree = "<group>"; };
 		72DB89992568F13D00BF7CC5 /* PhysicalWorldManager.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PhysicalWorldManager.hpp; sourceTree = "<group>"; };
+		72DB899D256916B100BF7CC5 /* PhysicalStage.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PhysicalStage.hpp; sourceTree = "<group>"; };
+		72DB899E256916B100BF7CC5 /* PhysicalStage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PhysicalStage.cpp; sourceTree = "<group>"; };
+		72DB899F256916B100BF7CC5 /* PhysicalCharacter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PhysicalCharacter.hpp; sourceTree = "<group>"; };
+		72DB89A0256916B100BF7CC5 /* PhysicalCharacter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PhysicalCharacter.cpp; sourceTree = "<group>"; };
 		C800DE7E253DE01800C3835B /* CharacterSelectionScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CharacterSelectionScene.cpp; sourceTree = "<group>"; };
 		C800DE7F253DE01900C3835B /* CharacterSelectionScene.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CharacterSelectionScene.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -614,6 +620,10 @@
 		72DB89972568F11000BF7CC5 /* physics */ = {
 			isa = PBXGroup;
 			children = (
+				72DB89A0256916B100BF7CC5 /* PhysicalCharacter.cpp */,
+				72DB899F256916B100BF7CC5 /* PhysicalCharacter.hpp */,
+				72DB899E256916B100BF7CC5 /* PhysicalStage.cpp */,
+				72DB899D256916B100BF7CC5 /* PhysicalStage.hpp */,
 				72DB89982568F13D00BF7CC5 /* PhysicalWorldManager.cpp */,
 				72DB89992568F13D00BF7CC5 /* PhysicalWorldManager.hpp */,
 			);
@@ -707,6 +717,7 @@
 				7247BB462568AB070052A75F /* Palette.cpp in Sources */,
 				72A3BDF625516856003393C4 /* ParameterizedCharacter.cpp in Sources */,
 				72A3BDCD254F09CF003393C4 /* HotReloadManager.cpp in Sources */,
+				72DB89A2256916B200BF7CC5 /* PhysicalCharacter.cpp in Sources */,
 				726F87E02556BAE2003FAC77 /* BattlePlayerManager.cpp in Sources */,
 				2C971A5C239732F900E66570 /* TitleScene.cpp in Sources */,
 				72A3BD95254C6197003393C4 /* Input.cpp in Sources */,
@@ -731,6 +742,7 @@
 				72A3BD7B25457D84003393C4 /* Axis.cpp in Sources */,
 				72A3BDF2255167C0003393C4 /* BattleDesc.cpp in Sources */,
 				72DB899A2568F13D00BF7CC5 /* PhysicalWorldManager.cpp in Sources */,
+				72DB89A1256916B200BF7CC5 /* PhysicalStage.cpp in Sources */,
 				72859F6D25388CA100EB0AAD /* UIComponent.cpp in Sources */,
 				72A3BDE0255137EB003393C4 /* SceneState.cpp in Sources */,
 				72A3BD59254427A9003393C4 /* Misc.cpp in Sources */,

--- a/Game/KANJI/KANJI.xcodeproj/project.pbxproj
+++ b/Game/KANJI/KANJI.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		72A3BDF625516856003393C4 /* ParameterizedCharacter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72A3BDF425516855003393C4 /* ParameterizedCharacter.cpp */; };
 		72A3BDFC255175C8003393C4 /* BattleUIManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72A3BDFA255175C8003393C4 /* BattleUIManager.cpp */; };
 		72DB89942568D97000BF7CC5 /* HolderUI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89922568D97000BF7CC5 /* HolderUI.cpp */; };
+		72DB899A2568F13D00BF7CC5 /* PhysicalWorldManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89982568F13D00BF7CC5 /* PhysicalWorldManager.cpp */; };
 		C800DE80253DE01900C3835B /* CharacterSelectionScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C800DE7E253DE01800C3835B /* CharacterSelectionScene.cpp */; };
 /* End PBXBuildFile section */
 
@@ -216,6 +217,8 @@
 		72A3BDFB255175C8003393C4 /* BattleUIManager.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = BattleUIManager.hpp; sourceTree = "<group>"; };
 		72DB89922568D97000BF7CC5 /* HolderUI.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = HolderUI.cpp; sourceTree = "<group>"; };
 		72DB89932568D97000BF7CC5 /* HolderUI.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = HolderUI.hpp; sourceTree = "<group>"; };
+		72DB89982568F13D00BF7CC5 /* PhysicalWorldManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PhysicalWorldManager.cpp; sourceTree = "<group>"; };
+		72DB89992568F13D00BF7CC5 /* PhysicalWorldManager.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PhysicalWorldManager.hpp; sourceTree = "<group>"; };
 		C800DE7E253DE01800C3835B /* CharacterSelectionScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CharacterSelectionScene.cpp; sourceTree = "<group>"; };
 		C800DE7F253DE01900C3835B /* CharacterSelectionScene.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CharacterSelectionScene.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -578,6 +581,7 @@
 		72A3BDEA255164BA003393C4 /* battle */ = {
 			isa = PBXGroup;
 			children = (
+				72DB89972568F11000BF7CC5 /* physics */,
 				726F87E82556C20E003FAC77 /* ui */,
 				726F87DD2556BABC003FAC77 /* player */,
 				72A3BDEB255164D6003393C4 /* BattleManager.cpp */,
@@ -605,6 +609,15 @@
 				72DB89932568D97000BF7CC5 /* HolderUI.hpp */,
 			);
 			path = ui;
+			sourceTree = "<group>";
+		};
+		72DB89972568F11000BF7CC5 /* physics */ = {
+			isa = PBXGroup;
+			children = (
+				72DB89982568F13D00BF7CC5 /* PhysicalWorldManager.cpp */,
+				72DB89992568F13D00BF7CC5 /* PhysicalWorldManager.hpp */,
+			);
+			path = physics;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -717,6 +730,7 @@
 				72A3BDFC255175C8003393C4 /* BattleUIManager.cpp in Sources */,
 				72A3BD7B25457D84003393C4 /* Axis.cpp in Sources */,
 				72A3BDF2255167C0003393C4 /* BattleDesc.cpp in Sources */,
+				72DB899A2568F13D00BF7CC5 /* PhysicalWorldManager.cpp in Sources */,
 				72859F6D25388CA100EB0AAD /* UIComponent.cpp in Sources */,
 				72A3BDE0255137EB003393C4 /* SceneState.cpp in Sources */,
 				72A3BD59254427A9003393C4 /* Misc.cpp in Sources */,

--- a/Game/KANJI/KANJI.xcodeproj/project.pbxproj
+++ b/Game/KANJI/KANJI.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		72DB899A2568F13D00BF7CC5 /* PhysicalWorldManager.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89982568F13D00BF7CC5 /* PhysicalWorldManager.cpp */; };
 		72DB89A1256916B200BF7CC5 /* PhysicalStage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB899E256916B100BF7CC5 /* PhysicalStage.cpp */; };
 		72DB89A2256916B200BF7CC5 /* PhysicalCharacter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89A0256916B100BF7CC5 /* PhysicalCharacter.cpp */; };
+		72DB89A6256929F100BF7CC5 /* PhysicalMove.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89A4256929F100BF7CC5 /* PhysicalMove.cpp */; };
+		72DB89AC2569321000BF7CC5 /* Move.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 72DB89AA2569321000BF7CC5 /* Move.cpp */; };
 		C800DE80253DE01900C3835B /* CharacterSelectionScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C800DE7E253DE01800C3835B /* CharacterSelectionScene.cpp */; };
 /* End PBXBuildFile section */
 
@@ -225,6 +227,10 @@
 		72DB899E256916B100BF7CC5 /* PhysicalStage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PhysicalStage.cpp; sourceTree = "<group>"; };
 		72DB899F256916B100BF7CC5 /* PhysicalCharacter.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PhysicalCharacter.hpp; sourceTree = "<group>"; };
 		72DB89A0256916B100BF7CC5 /* PhysicalCharacter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PhysicalCharacter.cpp; sourceTree = "<group>"; };
+		72DB89A4256929F100BF7CC5 /* PhysicalMove.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PhysicalMove.cpp; sourceTree = "<group>"; };
+		72DB89A5256929F100BF7CC5 /* PhysicalMove.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PhysicalMove.hpp; sourceTree = "<group>"; };
+		72DB89AA2569321000BF7CC5 /* Move.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Move.cpp; sourceTree = "<group>"; };
+		72DB89AB2569321000BF7CC5 /* Move.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Move.hpp; sourceTree = "<group>"; };
 		C800DE7E253DE01800C3835B /* CharacterSelectionScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CharacterSelectionScene.cpp; sourceTree = "<group>"; };
 		C800DE7F253DE01900C3835B /* CharacterSelectionScene.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = CharacterSelectionScene.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -291,6 +297,7 @@
 		2C1778981CE0AA7C00BB8AD0 /* src */ = {
 			isa = PBXGroup;
 			children = (
+				72DB89A9256931E100BF7CC5 /* masterdata */,
 				72DB898C2568D8FA00BF7CC5 /* character */,
 				7265F08025320F8700C15F67 /* application */,
 				72A3BDEA255164BA003393C4 /* battle */,
@@ -626,8 +633,19 @@
 				72DB899D256916B100BF7CC5 /* PhysicalStage.hpp */,
 				72DB89982568F13D00BF7CC5 /* PhysicalWorldManager.cpp */,
 				72DB89992568F13D00BF7CC5 /* PhysicalWorldManager.hpp */,
+				72DB89A4256929F100BF7CC5 /* PhysicalMove.cpp */,
+				72DB89A5256929F100BF7CC5 /* PhysicalMove.hpp */,
 			);
 			path = physics;
+			sourceTree = "<group>";
+		};
+		72DB89A9256931E100BF7CC5 /* masterdata */ = {
+			isa = PBXGroup;
+			children = (
+				72DB89AA2569321000BF7CC5 /* Move.cpp */,
+				72DB89AB2569321000BF7CC5 /* Move.hpp */,
+			);
+			path = masterdata;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -707,6 +725,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				72DB89AC2569321000BF7CC5 /* Move.cpp in Sources */,
 				72A3BD9F254D80AB003393C4 /* GamePadDemo.cpp in Sources */,
 				7265F0752531E1BF00C15F67 /* SequenceManager.cpp in Sources */,
 				72A3BDAD254DC083003393C4 /* BattleScene.cpp in Sources */,
@@ -714,6 +733,7 @@
 				72A3BD5E25443711003393C4 /* InputDemoScene.cpp in Sources */,
 				72A3BDED255164D7003393C4 /* BattleManager.cpp in Sources */,
 				7265F0712531DC1D00C15F67 /* AssetManager.cpp in Sources */,
+				72DB89A6256929F100BF7CC5 /* PhysicalMove.cpp in Sources */,
 				7247BB462568AB070052A75F /* Palette.cpp in Sources */,
 				72A3BDF625516856003393C4 /* ParameterizedCharacter.cpp in Sources */,
 				72A3BDCD254F09CF003393C4 /* HotReloadManager.cpp in Sources */,

--- a/Game/KANJI/src/battle/BattleManager.cpp
+++ b/Game/KANJI/src/battle/BattleManager.cpp
@@ -38,6 +38,7 @@ void BattleManager::initialize(const std::shared_ptr<BattleDesc>& desc) {
     m_player_mgr->players().at(dx::di::PlayerId::_3P)->setRadical(U"雨");
     m_player_mgr->players().at(dx::di::PlayerId::_4P)->setRadical(U"獣");
     m_world_mgr = std::make_shared<PhysicalWorldManager>();
+    m_world_mgr->initializeCharacters(m_player_mgr->players());
 }
 
 void BattleManager::update() {

--- a/Game/KANJI/src/battle/BattleManager.cpp
+++ b/Game/KANJI/src/battle/BattleManager.cpp
@@ -4,6 +4,8 @@
 #include "BattlePlayer.hpp"
 #include "ParameterizedCharacter.hpp"
 #include "PhysicalWorldManager.hpp"
+#include "PhysicalMove.hpp"
+#include "PhysicalCharacter.hpp"
 #include "Log.hpp"
 #include "Input.hpp"
 
@@ -39,20 +41,34 @@ void BattleManager::initialize(const std::shared_ptr<BattleDesc>& desc) {
     m_player_mgr->players().at(dx::di::PlayerId::_4P)->setRadical(U"獣");
     m_world_mgr = std::make_shared<PhysicalWorldManager>();
     m_world_mgr->initializeCharacters(m_player_mgr->players());
+    m_move_mgr = std::make_shared<PhysicalMoveManager>();
+    for (auto& player : m_player_mgr->players()) {
+        player.second->initializePhysical(m_world_mgr->characters().at(player.first));
+    }
 }
 
 void BattleManager::update() {
     // debug  -----------------
-    if (dx::di::Input::get(dx::di::GamePadId::_1P).buttons().a().down()) {
-        m_player_mgr->players().at(dx::di::PlayerId::_1P)->characters().at(0)->damage(5);
-    }
-    if (dx::di::Input::get(dx::di::GamePadId::_1P).buttons().b().down()) {
-        m_player_mgr->players().at(dx::di::PlayerId::_1P)->characters().at(1)->damage(5);
-    }
-    if (dx::di::Input::get(dx::di::GamePadId::_1P).buttons().x().down()) {
-        m_player_mgr->players().at(dx::di::PlayerId::_1P)->characters().at(2)->damage(5);
+    for (auto& player : m_player_mgr->players()) {
+        const auto pid = player.first;
+        if (dx::di::Input::get(pid).buttons().a().down()) {
+            const auto& physical = player.second->physical();
+            m_move_mgr->createMove(pid,
+                physical->isRight(),
+                physical->position(),
+                0);
+                // player.second->activeCharacter()->);
+            // player->activeCharacter()->damage(5);
+        }
+        if (dx::di::Input::get(pid).buttons().b().down()) {
+            m_player_mgr->players().at(pid)->characters().at(1)->damage(5);
+        }
+        if (dx::di::Input::get(pid).buttons().x().down()) {
+            m_player_mgr->players().at(pid)->characters().at(2)->damage(5);
+        }
     }
     m_world_mgr->update();
+    m_move_mgr->update(Scene::DeltaTime());
     // debug  -----------------
     m_timer->update();
 }

--- a/Game/KANJI/src/battle/BattleManager.cpp
+++ b/Game/KANJI/src/battle/BattleManager.cpp
@@ -3,6 +3,7 @@
 #include "BattlePlayerManager.hpp"
 #include "BattlePlayer.hpp"
 #include "ParameterizedCharacter.hpp"
+#include "PhysicalWorldManager.hpp"
 #include "Log.hpp"
 #include "Input.hpp"
 
@@ -36,6 +37,7 @@ void BattleManager::initialize(const std::shared_ptr<BattleDesc>& desc) {
     m_player_mgr->players().at(dx::di::PlayerId::_2P)->setRadical(U"土");
     m_player_mgr->players().at(dx::di::PlayerId::_3P)->setRadical(U"雨");
     m_player_mgr->players().at(dx::di::PlayerId::_4P)->setRadical(U"獣");
+    m_world_mgr = std::make_shared<PhysicalWorldManager>();
 }
 
 void BattleManager::update() {
@@ -49,6 +51,7 @@ void BattleManager::update() {
     if (dx::di::Input::get(dx::di::GamePadId::_1P).buttons().x().down()) {
         m_player_mgr->players().at(dx::di::PlayerId::_1P)->characters().at(2)->damage(5);
     }
+    m_world_mgr->update();
     // debug  -----------------
     m_timer->update();
 }

--- a/Game/KANJI/src/battle/BattleManager.cpp
+++ b/Game/KANJI/src/battle/BattleManager.cpp
@@ -53,12 +53,7 @@ void BattleManager::update() {
         const auto pid = player.first;
         if (dx::di::Input::get(pid).buttons().a().down()) {
             const auto& physical = player.second->physical();
-            m_move_mgr->createMove(pid,
-                physical->isRight(),
-                physical->position(),
-                0);
-                // player.second->activeCharacter()->);
-            // player->activeCharacter()->damage(5);
+            m_move_mgr->createMove(pid, physical, 0);
         }
         if (dx::di::Input::get(pid).buttons().b().down()) {
             m_player_mgr->players().at(pid)->characters().at(1)->damage(5);

--- a/Game/KANJI/src/battle/BattleManager.hpp
+++ b/Game/KANJI/src/battle/BattleManager.hpp
@@ -6,6 +6,7 @@ namespace battle {
 
 class BattlePlayerManager;
 class PhysicalWorldManager;
+class PhysicalMoveManager;
 
 class BattleTimer {
 public: // static_const/enum
@@ -36,6 +37,7 @@ public: // getter
     virtual std::shared_ptr<BattleResultDesc> createResultDesc() const = 0;
     virtual const std::shared_ptr<BattlePlayerManager>& playerMgr() const = 0;
     virtual const std::shared_ptr<PhysicalWorldManager>& worldMgr() const = 0;
+    virtual const std::shared_ptr<PhysicalMoveManager>& moveMgr() const = 0;
 public: // setter
     virtual void initialize(const std::shared_ptr<BattleDesc>& desc) = 0;
     virtual void update() = 0;
@@ -60,6 +62,9 @@ public: // getter
     const std::shared_ptr<PhysicalWorldManager>& worldMgr() const override {
         return m_world_mgr;
     }
+    const std::shared_ptr<PhysicalMoveManager>& moveMgr() const override {
+        return m_move_mgr;
+    }
 public: // setter
     void initialize(const std::shared_ptr<BattleDesc>& desc) override;
     void update() override;
@@ -70,6 +75,7 @@ private: // field
     std::shared_ptr<BattleTimer> m_timer;
     std::shared_ptr<BattlePlayerManager> m_player_mgr;
     std::shared_ptr<PhysicalWorldManager> m_world_mgr;
+    std::shared_ptr<PhysicalMoveManager> m_move_mgr;
 private: // private function
 public: // ctor/dtor
     BattleManager();

--- a/Game/KANJI/src/battle/BattleManager.hpp
+++ b/Game/KANJI/src/battle/BattleManager.hpp
@@ -5,6 +5,7 @@ namespace kanji {
 namespace battle {
 
 class BattlePlayerManager;
+class PhysicalWorldManager;
 
 class BattleTimer {
 public: // static_const/enum
@@ -34,6 +35,7 @@ public: // getter
     virtual bool hasGameSet() const = 0;
     virtual std::shared_ptr<BattleResultDesc> createResultDesc() const = 0;
     virtual const std::shared_ptr<BattlePlayerManager>& playerMgr() const = 0;
+    virtual const std::shared_ptr<PhysicalWorldManager>& worldMgr() const = 0;
 public: // setter
     virtual void initialize(const std::shared_ptr<BattleDesc>& desc) = 0;
     virtual void update() = 0;
@@ -55,6 +57,9 @@ public: // getter
     const std::shared_ptr<BattlePlayerManager>& playerMgr() const override {
         return m_player_mgr;
     }
+    const std::shared_ptr<PhysicalWorldManager>& worldMgr() const override {
+        return m_world_mgr;
+    }
 public: // setter
     void initialize(const std::shared_ptr<BattleDesc>& desc) override;
     void update() override;
@@ -64,6 +69,7 @@ public: // setter
 private: // field
     std::shared_ptr<BattleTimer> m_timer;
     std::shared_ptr<BattlePlayerManager> m_player_mgr;
+    std::shared_ptr<PhysicalWorldManager> m_world_mgr;
 private: // private function
 public: // ctor/dtor
     BattleManager();

--- a/Game/KANJI/src/battle/physics/PhysicalCharacter.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalCharacter.cpp
@@ -33,6 +33,9 @@ void PhysicalCharacter::update() {
         velocity.x *= m_param->air_resistance;
     }
     m_body.setVelocity(velocity);
+    
+    if (m_is_right && velocity.x < 0) { m_is_right = false; }
+    else if (!m_is_right && velocity.x > 0) { m_is_right = true; }
 }
 
 void PhysicalCharacter::drawLegacy() const {
@@ -44,10 +47,12 @@ void PhysicalCharacter::drawLegacy() const {
 PhysicalCharacter::PhysicalCharacter(
     s3d::P2World* world,
     dx::di::PlayerId pid,
+    bool is_right,
     const std::shared_ptr<chara::IParameterizedCharacter>& status,
     const std::shared_ptr<param::CharaPhysics>& param) :
 m_pid(pid),
 m_body(world->createRect(Vec2(0, -5), SizeF(2, 3), P2Material(1.0, 0.0, param->chara_friction))),
+m_is_right(is_right),
 m_status(status),
 m_param(param) {
     m_body.setFixedRotation(true);

--- a/Game/KANJI/src/battle/physics/PhysicalCharacter.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalCharacter.cpp
@@ -1,0 +1,58 @@
+#include "PhysicalCharacter.hpp"
+#include "HotReloadManager.hpp"
+#include "Input.hpp"
+#include "Misc.hpp"
+#include "BattlePlayer.hpp"
+#include "ParameterizedCharacter.hpp"
+
+namespace kanji {
+namespace battle {
+
+/* ---------- PhysicalCharacter ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+void PhysicalCharacter::update() {
+    const auto& input = dx::di::Input::get(m_pid);
+    s3d::Vec2 velocity(
+        m_param->force_horizontal * input.arrowL().x,
+        input.dpad().up().down() || input.buttons().b().down() ? -m_param->force_jump : 0.0);
+    // m_body.applyForce(force);
+    const auto& v = m_body.getVelocity();
+    if (dx::misc::approximatelyZero(velocity)) {
+        velocity.x = v.x * m_param->air_resistance;
+        velocity.y = v.y;
+    }
+    else {
+        if (dx::misc::approximatelyZero(velocity.x)) {
+            velocity.x = v.x;
+        }
+        if (dx::misc::approximatelyZero(velocity.y)) {
+            velocity.y = v.y;
+        }
+        velocity.x *= m_param->air_resistance;
+    }
+    m_body.setVelocity(velocity);
+}
+
+void PhysicalCharacter::drawLegacy() const {
+    m_body.draw();
+}
+    
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+PhysicalCharacter::PhysicalCharacter(
+    s3d::P2World* world,
+    dx::di::PlayerId pid,
+    const std::shared_ptr<chara::IParameterizedCharacter>& status,
+    const std::shared_ptr<param::CharaPhysics>& param) :
+m_pid(pid),
+m_body(world->createRect(Vec2(0, -5), SizeF(2, 3), P2Material(1.0, 0.0, param->chara_friction))),
+m_status(status),
+m_param(param) {
+    m_body.setFixedRotation(true);
+}
+
+
+}
+}

--- a/Game/KANJI/src/battle/physics/PhysicalCharacter.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalCharacter.hpp
@@ -14,11 +14,14 @@ class PhysicalCharacter {
 public: // static_const/enum
 public: // static
 public: // public function
+    bool isRight() const { return m_is_right; }
+    s3d::Vec2 position() const { return m_body.getPos(); }
     void update();
     void drawLegacy() const; // 近いうちに消す
 private: // field
     dx::di::PlayerId m_pid;
     P2Body m_body;
+    bool m_is_right; // 右向きか否か
     const std::shared_ptr<chara::IParameterizedCharacter> m_status;
     std::shared_ptr<param::CharaPhysics> m_param;
 private: // private function
@@ -26,6 +29,7 @@ public: // ctor/dtor
     PhysicalCharacter(
         s3d::P2World* world,
         dx::di::PlayerId pid,
+        bool is_right,
         const std::shared_ptr<chara::IParameterizedCharacter>& status,
         const std::shared_ptr<param::CharaPhysics>& param);
 };

--- a/Game/KANJI/src/battle/physics/PhysicalCharacter.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalCharacter.hpp
@@ -1,0 +1,34 @@
+#pragma once
+#include <unordered_map>
+#include <Siv3D.hpp>
+#include "PlayerId.hpp"
+#include "CharaPhysicsParameters.hpp"
+
+namespace kanji {
+namespace chara {
+class IParameterizedCharacter;
+}
+namespace battle {
+
+class PhysicalCharacter {
+public: // static_const/enum
+public: // static
+public: // public function
+    void update();
+    void drawLegacy() const; // 近いうちに消す
+private: // field
+    dx::di::PlayerId m_pid;
+    P2Body m_body;
+    const std::shared_ptr<chara::IParameterizedCharacter> m_status;
+    std::shared_ptr<param::CharaPhysics> m_param;
+private: // private function
+public: // ctor/dtor
+    PhysicalCharacter(
+        s3d::P2World* world,
+        dx::di::PlayerId pid,
+        const std::shared_ptr<chara::IParameterizedCharacter>& status,
+        const std::shared_ptr<param::CharaPhysics>& param);
+};
+
+}
+}

--- a/Game/KANJI/src/battle/physics/PhysicalMove.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalMove.cpp
@@ -3,5 +3,115 @@
 namespace kanji {
 namespace battle {
 
+/* ---------- MomentaryMove ---------- */
+
+// static ----------------------------------------
+MomentaryMove MomentaryMove::divideLinear(float t, const MomentaryMove& from, const MomentaryMove& to, bool is_right, const s3d::Vec2& origin) {
+    const float s = t / (to.time - from.time);
+    // TOdO: とりあえず全部線形補間してるけど変えたほうが良さそう
+    return MomentaryMove(
+        t,
+        static_cast<int>(s * to.damage + (1-s) * from.damage),
+        s3d::Circular( // TOdO: theta を isRight によって切り替える
+            s * to.shoot_force.r + (1-s) * from.shoot_force.r,
+            s * to.shoot_force.theta + (1-s) * from.shoot_force.theta),
+        divideHitboxLinear(t, from, to, is_right, origin)
+    );
+}
+s3d::RectF MomentaryMove::divideHitboxLinear(float t, const MomentaryMove& from, const MomentaryMove& to, bool is_right, const s3d::Vec2& origin) {
+    const float s = (t - from.time) / (to.time - from.time);
+    return s3d::RectF(s3d::Arg::center(
+        (s * to.hitbox.center().x + (1.f-s) * from.hitbox.center().x) * (is_right ? 1.f : -1.f) + origin.x,
+        s * to.hitbox.center().y + (1.f-s) * from.hitbox.center().y + origin.y),
+        s * to.hitbox.w + (1.f-s) * from.hitbox.w,
+        s * to.hitbox.h + (1.f-s) * from.hitbox.h);
+}
+// public function -------------------------------
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+MomentaryMove::MomentaryMove(float time, int damage, const s3d::Circular& shoot_force, const s3d::RectF& hitbox) :
+time(time), damage(damage), shoot_force(shoot_force), hitbox(hitbox) {}
+
+
+/* ---------- Trajectory ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+MomentaryMove Trajectory::momentary(float time, bool is_right, const s3d::Vec2& origin) const {
+    int index = -1;
+    for (int i = 0; i < m_moments.size(); ++i) {
+        if (time <= m_moments.at(i).time) {
+            index = i;
+        }
+    }
+    // if (index < 0) { return; }
+    return MomentaryMove::divideLinear(time, m_moments.at(index - 1), m_moments.at(index), is_right, origin);
+}
+
+s3d::RectF Trajectory::momentaryHitbox(float time, bool is_right, const s3d::Vec2& origin) const {
+    int index = -1;
+    for (int i = 0; i < m_moments.size(); ++i) {
+        if (time <= m_moments.at(i).time) {
+            index = i;
+            break;
+        }
+    }
+    // if (index < 0) { return; }
+    return MomentaryMove::divideHitboxLinear(time, m_moments.at(index - 1), m_moments.at(index), is_right, origin);
+}
+
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+
+
+/* ---------- PhysicalMove ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+MomentaryMove PhysicalMove::currentMoment() const {
+    return m_md->trajectory->momentary(m_timer, m_is_right, m_ownerChara->position());
+}
+s3d::RectF PhysicalMove::currentHitBox() const {
+    return m_md->trajectory->momentaryHitbox(m_timer, m_is_right, m_ownerChara->position());
+}
+
+bool PhysicalMove::update(float dt) {
+    m_timer += dt;
+    return m_timer > m_md->trajectory->totalTime();
+}
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+PhysicalMove::PhysicalMove(dx::di::PlayerId owner, const std::shared_ptr<battle::PhysicalCharacter>& ownerChara, md::MoveId moveId) :
+    m_timer(0),
+    m_owner(owner),
+    m_is_right(ownerChara->isRight()),
+    m_ownerChara(ownerChara),
+    m_md(md::MasterRepository::instance()->get(moveId)) {}
+
+
+/* ---------- PhysicalMoveManager ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+const std::shared_ptr<PhysicalMove>& PhysicalMoveManager::createMove(dx::di::PlayerId owner, const std::shared_ptr<PhysicalCharacter>& ownerChara, md::MoveId moveId) {
+    m_moves.push_back(std::make_shared<PhysicalMove>(owner, ownerChara, moveId));
+    return m_moves.back();
+}
+void PhysicalMoveManager::update(float dt) {
+    for (auto it = m_moves.begin(); it != m_moves.end();) {
+        if ((*it)->update(dt)) {
+            it = m_moves.erase(it);
+        }
+        else { ++it; }
+    }
+}
+
+const std::vector<std::shared_ptr<PhysicalMove>>& PhysicalMoveManager::moves() const {
+    return m_moves;
+}
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+
+
 }
 }

--- a/Game/KANJI/src/battle/physics/PhysicalMove.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalMove.cpp
@@ -1,0 +1,7 @@
+#include "PhysicalMove.hpp"
+
+namespace kanji {
+namespace battle {
+
+}
+}

--- a/Game/KANJI/src/battle/physics/PhysicalMove.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalMove.hpp
@@ -128,12 +128,9 @@ public: // public function
             else { ++it; }
         }
     }
-    void drawLegacy() const {
-        for (const auto& move : m_moves) {
-            const auto box = move->currentHitBox();
-            box.draw(s3d::Palette::Red);
-            // move->currentHitBox().draw(s3d::Palette::Red);
-        }
+    
+    const std::vector<std::shared_ptr<PhysicalMove>>& moves() const {
+        return m_moves;
     }
 private: // field
     std::vector<std::shared_ptr<PhysicalMove>> m_moves;

--- a/Game/KANJI/src/battle/physics/PhysicalMove.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalMove.hpp
@@ -1,0 +1,110 @@
+#pragma once
+#include <Siv3D/Vector2D.hpp>
+#include <Siv3D/Circular.hpp>
+#include <Siv3D/Rectangle.hpp>
+#include "PlayerId.hpp"
+#include "Move.hpp"
+
+namespace kanji {
+namespace battle {
+
+struct MomentaryMove {
+public: // field
+    const float time;
+    const int damage;
+    const s3d::Circular shoot_force;
+    const s3d::Rect hitbox;
+public: // static
+    static MomentaryMove divideLinear(float t, const MomentaryMove& from, const MomentaryMove& to) {
+        const float s = t / (to.time - from.time);
+        // TOdO: とりあえず全部線形補間してるけど変えたほうが良さそう
+        return MomentaryMove(
+            t,
+            static_cast<int>(s * to.damage + (1-s) * from.damage),
+            s3d::Circular(
+                s * to.shoot_force.r + (1-s) * from.shoot_force.r,
+                s * to.shoot_force.theta + (1-s) * from.shoot_force.theta),
+            divideHitboxLinear(t, from, to)
+        );
+    }
+    static s3d::RectF divideHitboxLinear(float t, const MomentaryMove& from, const MomentaryMove& to) {
+        const float s = t / (to.time - from.time);
+        return s3d::RectF(
+            s3d::Arg::center(
+                s * to.hitbox.center() + (1-s) * from.hitbox.center()),
+            s3d::Size(
+                static_cast<int>(s * to.hitbox.w + (1-s) * from.hitbox.w),
+                static_cast<int>(s * to.hitbox.h + (1-s) * from.hitbox.h)));
+    }
+public: // ctor/dtor
+    MomentaryMove(float time, int damage, const s3d::Circular& shoot_force, const s3d::Rect& hitbox) :
+    time(time), damage(damage), shoot_force(shoot_force), hitbox(hitbox) {}
+};
+
+class Trajectory {
+public: // static_const/enum
+public: // static
+public: // public function
+    float totalTime() const { return m_moments.back().time; }
+    MomentaryMove momentary(float time) const {
+        int index = -1;
+        for (int i = 0; i < m_moments.size(); ++i) {
+            if (time <= m_moments.at(i).time) {
+                index = i;
+            }
+        }
+        // if (index < 0) { return; }
+        return MomentaryMove::divideLinear(time, m_moments.at(index - 1), m_moments.at(index));
+    }
+    s3d::RectF momentaryHitbox(float time) const {
+        int index = -1;
+        for (int i = 0; i < m_moments.size(); ++i) {
+            if (time <= m_moments.at(i).time) {
+                index = i;
+            }
+        }
+        // if (index < 0) { return; }
+        return MomentaryMove::divideHitboxLinear(time, m_moments.at(index - 1), m_moments.at(index));
+    }
+private: // field
+    std::vector<MomentaryMove> m_moments;
+private: // private function
+public: // ctor/dtor
+    Trajectory(const std::vector<MomentaryMove>& moments) :
+        m_moments(moments) {}
+};
+
+using Move = md::Move;
+
+class PhysicalMove {
+public: // static_const/enum
+public: // static
+public: // public function
+    dx::di::PlayerId owner() const { return m_owner; }
+    MomentaryMove currentMoment() const {
+        return m_md->trajectory->momentary(m_timer);
+    }
+    s3d::RectF currentHitBox() const {
+        return m_md->trajectory->momentaryHitbox(m_timer);
+    }
+    
+    // 終了したらtrueを返す
+    bool update(float dt) {
+        m_timer += dt;
+        return m_timer > m_md->trajectory->totalTime();
+    }
+private: // field
+    dx::di::PlayerId m_owner;
+    float m_timer;
+    const std::shared_ptr<Move>& m_md;
+private: // private function
+public: // ctor/dtor
+    PhysicalMove(dx::di::PlayerId owner, md::MoveId moveId) :
+        m_owner(owner),
+        m_timer(0),
+        m_md(md::MasterRepository::instance()->get(moveId)) {}
+};
+
+
+}
+}

--- a/Game/KANJI/src/battle/physics/PhysicalMove.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalMove.hpp
@@ -15,23 +15,23 @@ public: // field
     const s3d::Circular shoot_force;
     const s3d::Rect hitbox;
 public: // static
-    static MomentaryMove divideLinear(float t, const MomentaryMove& from, const MomentaryMove& to) {
+    static MomentaryMove divideLinear(float t, const MomentaryMove& from, const MomentaryMove& to, bool is_right, const s3d::Vec2& origin) {
         const float s = t / (to.time - from.time);
         // TOdO: とりあえず全部線形補間してるけど変えたほうが良さそう
         return MomentaryMove(
             t,
             static_cast<int>(s * to.damage + (1-s) * from.damage),
-            s3d::Circular(
+            s3d::Circular( // TOdO: theta を isRight によって切り替える
                 s * to.shoot_force.r + (1-s) * from.shoot_force.r,
                 s * to.shoot_force.theta + (1-s) * from.shoot_force.theta),
-            divideHitboxLinear(t, from, to)
+            divideHitboxLinear(t, from, to, is_right, origin)
         );
     }
-    static s3d::RectF divideHitboxLinear(float t, const MomentaryMove& from, const MomentaryMove& to) {
+    static s3d::RectF divideHitboxLinear(float t, const MomentaryMove& from, const MomentaryMove& to, bool is_right, const s3d::Vec2& origin) {
         const float s = t / (to.time - from.time);
         return s3d::RectF(
-            s3d::Arg::center(
-                s * to.hitbox.center() + (1-s) * from.hitbox.center()),
+            s3d::Arg::center(origin + (is_right ? 1 : -1) *
+                (s * to.hitbox.center() + (1-s) * from.hitbox.center())),
             s3d::Size(
                 static_cast<int>(s * to.hitbox.w + (1-s) * from.hitbox.w),
                 static_cast<int>(s * to.hitbox.h + (1-s) * from.hitbox.h)));
@@ -46,7 +46,7 @@ public: // static_const/enum
 public: // static
 public: // public function
     float totalTime() const { return m_moments.back().time; }
-    MomentaryMove momentary(float time) const {
+    MomentaryMove momentary(float time, bool is_right, const s3d::Vec2& origin) const {
         int index = -1;
         for (int i = 0; i < m_moments.size(); ++i) {
             if (time <= m_moments.at(i).time) {
@@ -54,9 +54,9 @@ public: // public function
             }
         }
         // if (index < 0) { return; }
-        return MomentaryMove::divideLinear(time, m_moments.at(index - 1), m_moments.at(index));
+        return MomentaryMove::divideLinear(time, m_moments.at(index - 1), m_moments.at(index), is_right, origin);
     }
-    s3d::RectF momentaryHitbox(float time) const {
+    s3d::RectF momentaryHitbox(float time, bool is_right, const s3d::Vec2& origin) const {
         int index = -1;
         for (int i = 0; i < m_moments.size(); ++i) {
             if (time <= m_moments.at(i).time) {
@@ -64,7 +64,7 @@ public: // public function
             }
         }
         // if (index < 0) { return; }
-        return MomentaryMove::divideHitboxLinear(time, m_moments.at(index - 1), m_moments.at(index));
+        return MomentaryMove::divideHitboxLinear(time, m_moments.at(index - 1), m_moments.at(index), is_right, origin);
     }
 private: // field
     std::vector<MomentaryMove> m_moments;
@@ -82,10 +82,10 @@ public: // static
 public: // public function
     dx::di::PlayerId owner() const { return m_owner; }
     MomentaryMove currentMoment() const {
-        return m_md->trajectory->momentary(m_timer);
+        return m_md->trajectory->momentary(m_timer, m_is_right, m_origin);
     }
     s3d::RectF currentHitBox() const {
-        return m_md->trajectory->momentaryHitbox(m_timer);
+        return m_md->trajectory->momentaryHitbox(m_timer, m_is_right, m_origin);
     }
     
     // 終了したらtrueを返す
@@ -94,15 +94,49 @@ public: // public function
         return m_timer > m_md->trajectory->totalTime();
     }
 private: // field
-    dx::di::PlayerId m_owner;
     float m_timer;
+    dx::di::PlayerId m_owner;
+    bool m_is_right;
+    s3d::Vec2 m_origin;
     const std::shared_ptr<Move>& m_md;
 private: // private function
 public: // ctor/dtor
-    PhysicalMove(dx::di::PlayerId owner, md::MoveId moveId) :
-        m_owner(owner),
+    PhysicalMove(dx::di::PlayerId owner, bool is_right, const s3d::Vec2& origin, md::MoveId moveId) :
         m_timer(0),
+        m_owner(owner),
+        m_is_right(is_right),
+        m_origin(origin),
         m_md(md::MasterRepository::instance()->get(moveId)) {}
+};
+
+
+class PhysicalMoveManager {
+public: // static_const/enum
+public: // static
+public: // public function
+    const std::shared_ptr<PhysicalMove>& createMove(dx::di::PlayerId owner, bool is_right, const s3d::Vec2& origin, md::MoveId moveId) {
+        m_moves.push_back(std::make_shared<PhysicalMove>(owner, is_right, origin, moveId));
+        return m_moves.back();
+    }
+    void update(float dt) {
+        for (auto it = m_moves.begin(); it != m_moves.end();) {
+            if ((*it)->update(dt)) {
+                it = m_moves.erase(it);
+            }
+            else { ++it; }
+        }
+    }
+    void drawLegacy() const {
+        for (const auto& move : m_moves) {
+            const auto box = move->currentHitBox();
+            box.draw(s3d::Palette::Red);
+            // move->currentHitBox().draw(s3d::Palette::Red);
+        }
+    }
+private: // field
+    std::vector<std::shared_ptr<PhysicalMove>> m_moves;
+private: // private function
+public: // ctor/dtor
 };
 
 

--- a/Game/KANJI/src/battle/physics/PhysicalMove.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalMove.hpp
@@ -5,7 +5,6 @@
 #include "PlayerId.hpp"
 #include "Move.hpp"
 #include "PhysicalCharacter.hpp"
-#include "Log.hpp"
 
 namespace kanji {
 namespace battle {
@@ -17,29 +16,10 @@ public: // field
     const s3d::Circular shoot_force;
     const s3d::RectF hitbox;
 public: // static
-    static MomentaryMove divideLinear(float t, const MomentaryMove& from, const MomentaryMove& to, bool is_right, const s3d::Vec2& origin) {
-        const float s = t / (to.time - from.time);
-        // TOdO: とりあえず全部線形補間してるけど変えたほうが良さそう
-        return MomentaryMove(
-            t,
-            static_cast<int>(s * to.damage + (1-s) * from.damage),
-            s3d::Circular( // TOdO: theta を isRight によって切り替える
-                s * to.shoot_force.r + (1-s) * from.shoot_force.r,
-                s * to.shoot_force.theta + (1-s) * from.shoot_force.theta),
-            divideHitboxLinear(t, from, to, is_right, origin)
-        );
-    }
-    static s3d::RectF divideHitboxLinear(float t, const MomentaryMove& from, const MomentaryMove& to, bool is_right, const s3d::Vec2& origin) {
-        const float s = (t - from.time) / (to.time - from.time);
-        return s3d::RectF(s3d::Arg::center(
-            (s * to.hitbox.center().x + (1.f-s) * from.hitbox.center().x) * (is_right ? 1.f : -1.f) + origin.x,
-            s * to.hitbox.center().y + (1.f-s) * from.hitbox.center().y + origin.y),
-            s * to.hitbox.w + (1.f-s) * from.hitbox.w,
-            s * to.hitbox.h + (1.f-s) * from.hitbox.h);
-    }
+    static MomentaryMove divideLinear(float t, const MomentaryMove& from, const MomentaryMove& to, bool is_right, const s3d::Vec2& origin);
+    static s3d::RectF divideHitboxLinear(float t, const MomentaryMove& from, const MomentaryMove& to, bool is_right, const s3d::Vec2& origin);
 public: // ctor/dtor
-    MomentaryMove(float time, int damage, const s3d::Circular& shoot_force, const s3d::RectF& hitbox) :
-    time(time), damage(damage), shoot_force(shoot_force), hitbox(hitbox) {}
+    MomentaryMove(float time, int damage, const s3d::Circular& shoot_force, const s3d::RectF& hitbox);
 };
 
 class Trajectory {
@@ -47,27 +27,8 @@ public: // static_const/enum
 public: // static
 public: // public function
     float totalTime() const { return m_moments.back().time; }
-    MomentaryMove momentary(float time, bool is_right, const s3d::Vec2& origin) const {
-        int index = -1;
-        for (int i = 0; i < m_moments.size(); ++i) {
-            if (time <= m_moments.at(i).time) {
-                index = i;
-            }
-        }
-        // if (index < 0) { return; }
-        return MomentaryMove::divideLinear(time, m_moments.at(index - 1), m_moments.at(index), is_right, origin);
-    }
-    s3d::RectF momentaryHitbox(float time, bool is_right, const s3d::Vec2& origin) const {
-        int index = -1;
-        for (int i = 0; i < m_moments.size(); ++i) {
-            if (time <= m_moments.at(i).time) {
-                index = i;
-                break;
-            }
-        }
-        // if (index < 0) { return; }
-        return MomentaryMove::divideHitboxLinear(time, m_moments.at(index - 1), m_moments.at(index), is_right, origin);
-    }
+    MomentaryMove momentary(float time, bool is_right, const s3d::Vec2& origin) const;
+    s3d::RectF momentaryHitbox(float time, bool is_right, const s3d::Vec2& origin) const;
 private: // field
     std::vector<MomentaryMove> m_moments;
 private: // private function
@@ -83,18 +44,11 @@ public: // static_const/enum
 public: // static
 public: // public function
     dx::di::PlayerId owner() const { return m_owner; }
-    MomentaryMove currentMoment() const {
-        return m_md->trajectory->momentary(m_timer, m_is_right, m_ownerChara->position());
-    }
-    s3d::RectF currentHitBox() const {
-        return m_md->trajectory->momentaryHitbox(m_timer, m_is_right, m_ownerChara->position());
-    }
+    MomentaryMove currentMoment() const;
+    s3d::RectF currentHitBox() const;
     
     // 終了したらtrueを返す
-    bool update(float dt) {
-        m_timer += dt;
-        return m_timer > m_md->trajectory->totalTime();
-    }
+    bool update(float dt);
 private: // field
     float m_timer;
     dx::di::PlayerId m_owner;
@@ -103,12 +57,7 @@ private: // field
     const std::shared_ptr<Move>& m_md;
 private: // private function
 public: // ctor/dtor
-    PhysicalMove(dx::di::PlayerId owner, const std::shared_ptr<battle::PhysicalCharacter>& ownerChara, md::MoveId moveId) :
-        m_timer(0),
-        m_owner(owner),
-        m_is_right(ownerChara->isRight()),
-        m_ownerChara(ownerChara),
-        m_md(md::MasterRepository::instance()->get(moveId)) {}
+    PhysicalMove(dx::di::PlayerId owner, const std::shared_ptr<battle::PhysicalCharacter>& ownerChara, md::MoveId moveId);
 };
 
 
@@ -116,22 +65,10 @@ class PhysicalMoveManager {
 public: // static_const/enum
 public: // static
 public: // public function
-    const std::shared_ptr<PhysicalMove>& createMove(dx::di::PlayerId owner, const std::shared_ptr<PhysicalCharacter>& ownerChara, md::MoveId moveId) {
-        m_moves.push_back(std::make_shared<PhysicalMove>(owner, ownerChara, moveId));
-        return m_moves.back();
-    }
-    void update(float dt) {
-        for (auto it = m_moves.begin(); it != m_moves.end();) {
-            if ((*it)->update(dt)) {
-                it = m_moves.erase(it);
-            }
-            else { ++it; }
-        }
-    }
+    const std::shared_ptr<PhysicalMove>& createMove(dx::di::PlayerId owner, const std::shared_ptr<PhysicalCharacter>& ownerChara, md::MoveId moveId);
+    void update(float dt);
     
-    const std::vector<std::shared_ptr<PhysicalMove>>& moves() const {
-        return m_moves;
-    }
+    const std::vector<std::shared_ptr<PhysicalMove>>& moves() const;
 private: // field
     std::vector<std::shared_ptr<PhysicalMove>> m_moves;
 private: // private function

--- a/Game/KANJI/src/battle/physics/PhysicalStage.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalStage.cpp
@@ -1,0 +1,28 @@
+#include "PhysicalStage.hpp"
+#include "HotReloadManager.hpp"
+
+namespace kanji {
+namespace battle {
+
+
+/* ---------- PhysicalStage ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+void PhysicalStage::drawLegacy() const {
+    m_floor.draw(Palette::Skyblue);
+    m_ceiling.draw(Palette::Skyblue);
+    m_wall_left.draw(Palette::Skyblue);
+    m_wall_right.draw(Palette::Skyblue);
+}
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+PhysicalStage::PhysicalStage(s3d::P2World* world, const std::shared_ptr<param::CharaPhysics>& param) :
+m_floor     (world->createStaticLine(Vec2(  0,  0), Line(-25, 0, 25, 0), P2Material(1.0, 0.0, param->floor_friction))),
+m_ceiling   (world->createStaticLine(Vec2(  0,-25), Line(-25, 0, 25, 0), P2Material(1.0, 0.0, param->ceiling_friction))),
+m_wall_left (world->createStaticLine(Vec2(-25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction))),
+m_wall_right(world->createStaticLine(Vec2( 25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction))) {}
+
+
+}
+}

--- a/Game/KANJI/src/battle/physics/PhysicalStage.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalStage.hpp
@@ -1,0 +1,26 @@
+#pragma once
+#include <unordered_map>
+#include <Siv3D.hpp>
+#include "PlayerId.hpp"
+#include "CharaPhysicsParameters.hpp"
+
+namespace kanji {
+namespace battle {
+
+class PhysicalStage {
+public: // static_const/enum
+public: // static
+public: // public function
+    void drawLegacy() const; // 近いうちに消す
+private: // field
+    const P2Body m_floor;
+    const P2Body m_ceiling;
+    const P2Body m_wall_left;
+    const P2Body m_wall_right;
+private: // private function
+public: // ctor/dtor
+    PhysicalStage(s3d::P2World* world, const std::shared_ptr<param::CharaPhysics>& param);
+};
+
+}
+}

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
@@ -33,39 +33,27 @@ void PhysicalWorldManager::update() {
     for (auto& chara : m_characters) {
         chara.second->update();
     }
-    m_camera.update();
-    { // 2D カメラの設定から Transformer2D を作成・適用
-        const auto t = m_camera.createTransformer();
-        if (MouseL.down()) {
-            // クリックした場所にボールを作成
-            m_bodies << m_world.createCircle(Cursor::PosF(), 0.5);
-        }
-    }
+    // クリックした場所にボールを作成
+    // m_bodies << m_world.createCircle(Cursor::PosF(), 0.5);
     // (y > 10) まで落下した P2Body は削除
     m_bodies.remove_if([](const P2Body& body) { return body.getPos().y > 10; });
 }
 
 void PhysicalWorldManager::drawLegacy() const {
-    {
-        // 2D カメラの設定から Transformer2D を作成・適用
-        const auto t = m_camera.createTransformer();
-        m_stage->drawLegacy();
-        for (const auto& chara : m_characters) {
-            chara.second->drawLegacy();
-        }
-        
-        // 物体を描画
-        for (const auto& body : m_bodies) {
-            body.draw(HSV(body.id() * 10, 0.7, 0.9));
-        }
+    m_stage->drawLegacy();
+    for (const auto& chara : m_characters) {
+        chara.second->drawLegacy();
     }
-    m_camera.draw();
+
+    // 物体を描画
+    // for (const auto& body : m_bodies) {
+    //     body.draw(HSV(body.id() * 10, 0.7, 0.9));
+    // }
 }
 // private function ------------------------------
 // ctor/dtor -------------------------------------
 PhysicalWorldManager::PhysicalWorldManager() :
 m_param(dx::cmp::HotReloadManager::createParams<param::CharaPhysics>()),
-m_camera(Vec2(0, -8), 20.0, s3d::Camera2DParameters::MouseOnly()),
 m_world(9.8) {
     m_stage = std::make_shared<PhysicalStage>(&m_world, m_param);
 }

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
@@ -1,76 +1,11 @@
 #include "PhysicalWorldManager.hpp"
 #include "HotReloadManager.hpp"
-#include "Input.hpp"
-#include "Misc.hpp"
 #include "BattlePlayer.hpp"
-#include "ParameterizedCharacter.hpp"
+#include "PhysicalCharacter.hpp"
+#include "PhysicalStage.hpp"
 
 namespace kanji {
 namespace battle {
-
-/* ---------- PhysicalCharacter ---------- */
-
-// static ----------------------------------------
-// public function -------------------------------
-void PhysicalCharacter::update() {
-    const auto& input = dx::di::Input::get(m_pid);
-    s3d::Vec2 velocity(
-        m_param->force_horizontal * input.arrowL().x,
-        input.dpad().up().down() || input.buttons().b().down() ? -m_param->force_jump : 0.0);
-    // m_body.applyForce(force);
-    const auto& v = m_body.getVelocity();
-    if (dx::misc::approximatelyZero(velocity)) {
-        velocity.x = v.x * m_param->air_resistance;
-        velocity.y = v.y;
-    }
-    else {
-        if (dx::misc::approximatelyZero(velocity.x)) {
-            velocity.x = v.x;
-        }
-        if (dx::misc::approximatelyZero(velocity.y)) {
-            velocity.y = v.y;
-        }
-        velocity.x *= m_param->air_resistance;
-    }
-    m_body.setVelocity(velocity);
-}
-
-void PhysicalCharacter::drawLegacy() const {
-    m_body.draw();
-}
-    
-// private function ------------------------------
-// ctor/dtor -------------------------------------
-PhysicalCharacter::PhysicalCharacter(
-    s3d::P2World* world,
-    dx::di::PlayerId pid,
-    const std::shared_ptr<chara::IParameterizedCharacter>& status,
-    const std::shared_ptr<param::CharaPhysics>& param) :
-m_pid(pid),
-m_body(world->createRect(Vec2(0, -5), SizeF(2, 3), P2Material(1.0, 0.0, param->chara_friction))),
-m_status(status),
-m_param(param) {
-    m_body.setFixedRotation(true);
-}
-
-
-/* ---------- PhysicalStage ---------- */
-
-// static ----------------------------------------
-// public function -------------------------------
-void PhysicalStage::drawLegacy() const {
-    m_floor.draw(Palette::Skyblue);
-    m_ceiling.draw(Palette::Skyblue);
-    m_wall_left.draw(Palette::Skyblue);
-    m_wall_right.draw(Palette::Skyblue);
-}
-// private function ------------------------------
-// ctor/dtor -------------------------------------
-PhysicalStage::PhysicalStage(s3d::P2World* world, const std::shared_ptr<param::CharaPhysics>& param) :
-m_floor     (world->createStaticLine(Vec2(  0,  0), Line(-25, 0, 25, 0), P2Material(1.0, 0.0, param->floor_friction))),
-m_ceiling   (world->createStaticLine(Vec2(  0,-25), Line(-25, 0, 25, 0), P2Material(1.0, 0.0, param->ceiling_friction))),
-m_wall_left (world->createStaticLine(Vec2(-25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction))),
-m_wall_right(world->createStaticLine(Vec2( 25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction))) {}
 
 
 /* ---------- PhysicalWorldManager ---------- */

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
@@ -1,0 +1,98 @@
+#include "PhysicalWorldManager.hpp"
+#include "HotReloadManager.hpp"
+#include "Input.hpp"
+#include "Misc.hpp"
+
+namespace kanji {
+namespace battle {
+
+/* ---------- PhysicalWorldManager ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+void PhysicalWorldManager::update() {
+    // ↓ここから下は試し書きの無法地帯
+    // 物理演算の精度
+    static constexpr int32 velocityIterations = 12;
+    static constexpr int32 positionIterations = 4;
+    
+    // (y > 10) まで落下した P2Body は削除
+    m_bodies.remove_if([](const P2Body& body) { return body.getPos().y > 10; });
+
+    // 物理演算のワールドを更新
+    m_world.update(true ? (1.0 / 60.0) : Scene::DeltaTime(), velocityIterations, positionIterations);
+        
+
+    m_camera.update();
+    {
+        // 2D カメラの設定から Transformer2D を作成・適用
+        const auto t = m_camera.createTransformer();
+        
+        if (MouseL.down()) {
+            // クリックした場所にボールを作成
+            m_bodies << m_world.createCircle(Cursor::PosF(), 0.5);
+        }
+        const auto& input = dx::di::Input::get(dx::di::GamePadId::_1P);
+        s3d::Vec2 velocity(
+            param->force_horizontal * input.arrowL().x,
+            input.dpad().up().down() || input.buttons().b().down() ? -param->force_jump : 0.0);
+        // m_chara.applyForce(force);
+        const auto& v = m_chara.getVelocity();
+        if (dx::misc::approximatelyZero(velocity)) {
+            velocity.x = v.x * param->air_resistance;
+            velocity.y = v.y;
+        }
+        else {
+            if (dx::misc::approximatelyZero(velocity.x)) {
+                velocity.x = v.x;
+            }
+            if (dx::misc::approximatelyZero(velocity.y)) {
+                velocity.y = v.y;
+            }
+            velocity.x *= param->air_resistance;
+        }
+        m_chara.setVelocity(velocity);
+    }
+}
+
+void PhysicalWorldManager::drawLegacy() const {
+    {
+        // 2D カメラの設定から Transformer2D を作成・適用
+        const auto t = m_camera.createTransformer();
+        
+        // 床を描画
+        m_floor.draw(Palette::Skyblue);
+        m_ceiling.draw(Palette::Skyblue);
+        m_wall_left.draw(Palette::Skyblue);
+        m_wall_right.draw(Palette::Skyblue);
+        
+        // 物体を描画
+        for (const auto& body : m_bodies) {
+            body.draw(HSV(body.id() * 10, 0.7, 0.9));
+        }
+        m_chara.draw();
+    }
+    m_camera.draw();
+}
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+PhysicalWorldManager::PhysicalWorldManager() :
+param(dx::cmp::HotReloadManager::createParams<param::CharaPhysics>()),
+m_camera(Vec2(0, -8), 20.0, s3d::Camera2DParameters::MouseOnly()),
+m_world(9.8),
+m_chara     (m_world.createRect      (Vec2(  0, -5), SizeF(2, 3),         P2Material(1.0, 0.0, param->chara_friction))),
+m_floor     (m_world.createStaticLine(Vec2(  0,  0), Line(-25, 0, 25, 0), P2Material(1.0, 0.0, param->floor_friction))),
+m_ceiling   (m_world.createStaticLine(Vec2(  0,-25), Line(-25, 0, 25, 0), P2Material(1.0, 0.0, param->ceiling_friction))),
+m_wall_left (m_world.createStaticLine(Vec2(-25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction))),
+m_wall_right(m_world.createStaticLine(Vec2( 25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction)))
+{
+    m_chara.setFixedRotation(true);
+    // 物理演算のワールド更新に 60FPS の定数時間を使う場合は true, 実時間を使う場合 false
+    constexpr bool useConstantDeltaTime = true;
+    if (useConstantDeltaTime) { // フレームレート上限を 60 FPS に
+        Graphics::SetTargetFrameRateHz(60);
+    }
+}
+    
+}
+}

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
@@ -20,7 +20,7 @@ void PhysicalWorldManager::update() {
     m_bodies.remove_if([](const P2Body& body) { return body.getPos().y > 10; });
 
     // 物理演算のワールドを更新
-    m_world.update(true ? (1.0 / 60.0) : Scene::DeltaTime(), velocityIterations, positionIterations);
+    m_world.update(Scene::DeltaTime(), velocityIterations, positionIterations);
         
 
     m_camera.update();
@@ -87,11 +87,6 @@ m_wall_left (m_world.createStaticLine(Vec2(-25,  0), Line(0, -25, 0, 10), P2Mate
 m_wall_right(m_world.createStaticLine(Vec2( 25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction)))
 {
     m_chara.setFixedRotation(true);
-    // 物理演算のワールド更新に 60FPS の定数時間を使う場合は true, 実時間を使う場合 false
-    constexpr bool useConstantDeltaTime = true;
-    if (useConstantDeltaTime) { // フレームレート上限を 60 FPS に
-        Graphics::SetTargetFrameRateHz(60);
-    }
 }
     
 }

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.cpp
@@ -18,6 +18,7 @@ void PhysicalWorldManager::initializeCharacters(const std::unordered_map<dx::di:
             std::make_shared<PhysicalCharacter>(
                 &m_world,
                 player.first,
+                true,
                 player.second->activeCharacter(),
                 m_param)
             ));
@@ -29,14 +30,12 @@ void PhysicalWorldManager::update() {
     static constexpr int32 velocityIterations = 12;
     static constexpr int32 positionIterations = 4;
     m_world.update(Scene::DeltaTime(), velocityIterations, positionIterations);
+    for (auto& chara : m_characters) {
+        chara.second->update();
+    }
     m_camera.update();
-    {
-        // 2D カメラの設定から Transformer2D を作成・適用
+    { // 2D カメラの設定から Transformer2D を作成・適用
         const auto t = m_camera.createTransformer();
-        for (auto& chara : m_characters) {
-            chara.second->update();
-        }
-        
         if (MouseL.down()) {
             // クリックした場所にボールを作成
             m_bodies << m_world.createCircle(Cursor::PosF(), 0.5);

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
@@ -5,48 +5,10 @@
 #include "CharaPhysicsParameters.hpp"
 
 namespace kanji {
-namespace chara {
-class IParameterizedCharacter;
-}
 namespace battle {
 class BattlePlayer;
-
-class PhysicalCharacter {
-public: // static_const/enum
-public: // static
-public: // public function
-    void update();
-    void drawLegacy() const; // 近いうちに消す
-private: // field
-    dx::di::PlayerId m_pid;
-    P2Body m_body;
-    const std::shared_ptr<chara::IParameterizedCharacter> m_status;
-    std::shared_ptr<param::CharaPhysics> m_param;
-private: // private function
-public: // ctor/dtor
-    PhysicalCharacter(
-        s3d::P2World* world,
-        dx::di::PlayerId pid,
-        const std::shared_ptr<chara::IParameterizedCharacter>& status,
-        const std::shared_ptr<param::CharaPhysics>& param);
-};
-
-
-class PhysicalStage {
-public: // static_const/enum
-public: // static
-public: // public function
-    void drawLegacy() const; // 近いうちに消す
-private: // field
-    const P2Body m_floor;
-    const P2Body m_ceiling;
-    const P2Body m_wall_left;
-    const P2Body m_wall_right;
-private: // private function
-public: // ctor/dtor
-    PhysicalStage(s3d::P2World* world, const std::shared_ptr<param::CharaPhysics>& param);
-};
-
+class PhysicalCharacter;
+class PhysicalStage;
 
 class PhysicalWorldManager {
 public: // static_const/enum

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
@@ -1,9 +1,15 @@
 #pragma once
+#include <unordered_map>
 #include <Siv3D.hpp>
+#include "PlayerId.hpp"
 #include "CharaPhysicsParameters.hpp"
 
 namespace kanji {
+namespace chara {
+class IParameterizedCharacter;
+}
 namespace battle {
+class BattlePlayer;
 
 class PhysicalCharacter {
 public: // static_const/enum
@@ -12,11 +18,17 @@ public: // public function
     void update();
     void drawLegacy() const; // 近いうちに消す
 private: // field
+    dx::di::PlayerId m_pid;
     P2Body m_body;
+    const std::shared_ptr<chara::IParameterizedCharacter> m_status;
     std::shared_ptr<param::CharaPhysics> m_param;
 private: // private function
 public: // ctor/dtor
-    PhysicalCharacter(s3d::P2World* world, const std::shared_ptr<param::CharaPhysics>& param);
+    PhysicalCharacter(
+        s3d::P2World* world,
+        dx::di::PlayerId pid,
+        const std::shared_ptr<chara::IParameterizedCharacter>& status,
+        const std::shared_ptr<param::CharaPhysics>& param);
 };
 
 
@@ -40,6 +52,7 @@ class PhysicalWorldManager {
 public: // static_const/enum
 public: // static
 public: // public function
+    void initializeCharacters(const std::unordered_map<dx::di::PlayerId, std::shared_ptr<BattlePlayer>>& players);
     void update();
     void drawLegacy() const; // 近いうちに消す
 private: // field
@@ -47,7 +60,7 @@ private: // field
 
     Camera2D m_camera;
     P2World m_world;
-    std::shared_ptr<PhysicalCharacter> m_chara;
+    std::unordered_map<dx::di::PlayerId, std::shared_ptr<PhysicalCharacter>> m_characters;
     std::shared_ptr<PhysicalStage> m_stage;
     
     // テスト用剛体球

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
@@ -20,6 +20,22 @@ public: // ctor/dtor
 };
 
 
+class PhysicalStage {
+public: // static_const/enum
+public: // static
+public: // public function
+    void drawLegacy() const; // 近いうちに消す
+private: // field
+    const P2Body m_floor;
+    const P2Body m_ceiling;
+    const P2Body m_wall_left;
+    const P2Body m_wall_right;
+private: // private function
+public: // ctor/dtor
+    PhysicalStage(s3d::P2World* world, const std::shared_ptr<param::CharaPhysics>& param);
+};
+
+
 class PhysicalWorldManager {
 public: // static_const/enum
 public: // static
@@ -27,20 +43,15 @@ public: // public function
     void update();
     void drawLegacy() const; // 近いうちに消す
 private: // field
-    // ↓ここから下は試し書きの無法地帯
-    std::shared_ptr<param::CharaPhysics> param;
+    std::shared_ptr<param::CharaPhysics> m_param;
 
-    // 2Dカメラ
     Camera2D m_camera;
-    // 物理演算用のワールド
     P2World m_world;
     std::shared_ptr<PhysicalCharacter> m_chara;
+    std::shared_ptr<PhysicalStage> m_stage;
+    
+    // テスト用剛体球
     Array<P2Body> m_bodies;
-    // 床
-    const P2Body m_floor;
-    const P2Body m_ceiling;
-    const P2Body m_wall_left;
-    const P2Body m_wall_right;
 private: // private function
 public: // ctor/dtor
     PhysicalWorldManager();

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
@@ -5,12 +5,26 @@
 namespace kanji {
 namespace battle {
 
+class PhysicalCharacter {
+public: // static_const/enum
+public: // static
+public: // public function
+    void update();
+    void drawLegacy() const; // 近いうちに消す
+private: // field
+    P2Body m_body;
+    std::shared_ptr<param::CharaPhysics> m_param;
+private: // private function
+public: // ctor/dtor
+    PhysicalCharacter(s3d::P2World* world, const std::shared_ptr<param::CharaPhysics>& param);
+};
+
+
 class PhysicalWorldManager {
 public: // static_const/enum
 public: // static
 public: // public function
     void update();
-    // void updateLegacy(); // 近いうちに消す
     void drawLegacy() const; // 近いうちに消す
 private: // field
     // ↓ここから下は試し書きの無法地帯
@@ -20,8 +34,7 @@ private: // field
     Camera2D m_camera;
     // 物理演算用のワールド
     P2World m_world;
-    // 物体
-    P2Body m_chara;
+    std::shared_ptr<PhysicalCharacter> m_chara;
     Array<P2Body> m_bodies;
     // 床
     const P2Body m_floor;

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
@@ -17,6 +17,10 @@ public: // public function
     void initializeCharacters(const std::unordered_map<dx::di::PlayerId, std::shared_ptr<BattlePlayer>>& players);
     void update();
     void drawLegacy() const; // 近いうちに消す
+    
+    const std::unordered_map<dx::di::PlayerId, std::shared_ptr<PhysicalCharacter>>& characters() const {
+        return m_characters;
+    }
 private: // field
     std::shared_ptr<param::CharaPhysics> m_param;
 

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
@@ -1,0 +1,38 @@
+#pragma once
+#include <Siv3D.hpp>
+#include "CharaPhysicsParameters.hpp"
+
+namespace kanji {
+namespace battle {
+
+class PhysicalWorldManager {
+public: // static_const/enum
+public: // static
+public: // public function
+    void update();
+    // void updateLegacy(); // 近いうちに消す
+    void drawLegacy() const; // 近いうちに消す
+private: // field
+    // ↓ここから下は試し書きの無法地帯
+    std::shared_ptr<param::CharaPhysics> param;
+
+    // 2Dカメラ
+    Camera2D m_camera;
+    // 物理演算用のワールド
+    P2World m_world;
+    // 物体
+    P2Body m_chara;
+    Array<P2Body> m_bodies;
+    // 床
+    const P2Body m_floor;
+    const P2Body m_ceiling;
+    const P2Body m_wall_left;
+    const P2Body m_wall_right;
+private: // private function
+public: // ctor/dtor
+    PhysicalWorldManager();
+    
+};
+
+}
+}

--- a/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
+++ b/Game/KANJI/src/battle/physics/PhysicalWorldManager.hpp
@@ -24,7 +24,6 @@ public: // public function
 private: // field
     std::shared_ptr<param::CharaPhysics> m_param;
 
-    Camera2D m_camera;
     P2World m_world;
     std::unordered_map<dx::di::PlayerId, std::shared_ptr<PhysicalCharacter>> m_characters;
     std::shared_ptr<PhysicalStage> m_stage;

--- a/Game/KANJI/src/battle/player/BattlePlayer.hpp
+++ b/Game/KANJI/src/battle/player/BattlePlayer.hpp
@@ -15,6 +15,12 @@ public: // static_const/enum
 public: // static
 public: // public function
     dx::di::PlayerId pid() const { return m_pid; }
+    std::shared_ptr<chara::IParameterizedCharacter> activeCharacter() {
+        if (0 <= m_activeIndex && m_activeIndex < m_characters.size()) {
+            return m_characters.at(m_activeIndex);
+        }
+        else { return nullptr; }
+    }
     const std::vector<std::shared_ptr<chara::IParameterizedCharacter>>& characters() const {
         return m_characters;
     }
@@ -24,6 +30,7 @@ public: // public function
     
 private: // field
     dx::di::PlayerId m_pid;
+    int m_activeIndex;
     std::vector<std::shared_ptr<chara::IParameterizedCharacter>> m_characters;
     Radical m_radical;
 private: // private function

--- a/Game/KANJI/src/battle/player/BattlePlayer.hpp
+++ b/Game/KANJI/src/battle/player/BattlePlayer.hpp
@@ -7,6 +7,7 @@ namespace chara {
 class IParameterizedCharacter;
 }
 namespace battle {
+class PhysicalCharacter;
 class BattlePlayerDesc;
 
 class BattlePlayer {
@@ -27,12 +28,17 @@ public: // public function
     bool hasRadical() const { return m_radical != U""; }
     const Radical& radical() const { return m_radical; }
     void setRadical(const Radical& value) { m_radical = value; }
+    const std::shared_ptr<PhysicalCharacter>& physical() { return m_physical; }
+    void initializePhysical(const std::shared_ptr<PhysicalCharacter>& physical) {
+        m_physical = physical;
+    }
     
 private: // field
     dx::di::PlayerId m_pid;
     int m_activeIndex;
     std::vector<std::shared_ptr<chara::IParameterizedCharacter>> m_characters;
     Radical m_radical;
+    std::shared_ptr<PhysicalCharacter> m_physical;
 private: // private function
 public: // ctor/dtor
     BattlePlayer(dx::di::PlayerId pid, const std::shared_ptr<BattlePlayerDesc>& desc);

--- a/Game/KANJI/src/battle/ui/BattleUIManager.cpp
+++ b/Game/KANJI/src/battle/ui/BattleUIManager.cpp
@@ -17,7 +17,10 @@ namespace ui {
 void MoveUIManager::update() {}
 // protected function ------------------------------
 void MoveUIManager::drawImpl() const {
-    m_move_mgr->drawLegacy();
+    for (const auto& move : m_move_mgr->moves()) {
+        const auto box = move->currentHitBox();
+        box.draw(dx::di::Id::ToColor(move->owner()));
+    }
 }
 // private function ------------------------------
 // ctor/dtor -------------------------------------

--- a/Game/KANJI/src/battle/ui/BattleUIManager.cpp
+++ b/Game/KANJI/src/battle/ui/BattleUIManager.cpp
@@ -3,10 +3,43 @@
 #include "BattlePlayerManager.hpp"
 #include "BattlePlayer.hpp"
 #include "PhysicalWorldManager.hpp"
+#include "PhysicalMove.hpp"
 #include "HolderUI.hpp"
 
 namespace kanji {
 namespace ui {
+
+
+/* ---------- MoveUIManager ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+void MoveUIManager::update() {}
+// protected function ------------------------------
+void MoveUIManager::drawImpl() const {
+    m_move_mgr->drawLegacy();
+}
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+MoveUIManager::MoveUIManager(const battle::PhysicalMoveManager* move_mgr) :
+m_move_mgr(move_mgr) {}
+
+
+
+/* ---------- PhysicalWorldUIManager ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+void PhysicalWorldUIManager::update() {}
+// protected function ------------------------------
+void PhysicalWorldUIManager::drawImpl() const {
+    m_world_mgr->drawLegacy();
+}
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+PhysicalWorldUIManager::PhysicalWorldUIManager(const battle::PhysicalWorldManager* world_mgr) :
+m_world_mgr(world_mgr) {}
+
 
 
 /* ---------- BattleUIManager ---------- */
@@ -14,6 +47,7 @@ namespace ui {
 // static ----------------------------------------
 // public function -------------------------------
 void BattleUIManager::update() {
+    m_camera.update();
     for (auto& holder : m_holders) {
         holder.second->update();
     }
@@ -23,13 +57,21 @@ void BattleUIManager::drawImpl() const {
     for (const auto& holder : m_holders) {
         holder.second->draw();
     }
-    m_battle_manager->worldMgr()->drawLegacy();
+    {
+        const auto t = m_camera.createTransformer();
+        m_world->draw();
+        m_moves->draw();
+    }
+    m_camera.draw();
 }
 
 // private function ------------------------------
 // ctor/dtor -------------------------------------
-BattleUIManager::BattleUIManager(const battle::IBattleManager* battle_manager) :
-m_battle_manager(battle_manager) {
+BattleUIManager::BattleUIManager(const battle::IBattleManager* battle_mgr) :
+m_camera(Vec2(0, -8), 20.0, s3d::Camera2DParameters::MouseOnly()),
+m_battle_manager(battle_mgr),
+m_world(std::make_shared<PhysicalWorldUIManager>(battle_mgr->worldMgr().get())),
+m_moves(std::make_shared<MoveUIManager>(battle_mgr->moveMgr().get())) {
     const auto& players = m_battle_manager->playerMgr()->players();
     const int player_num = static_cast<int>(players.size());
     for (int i = 0; const auto& player : players) {

--- a/Game/KANJI/src/battle/ui/BattleUIManager.cpp
+++ b/Game/KANJI/src/battle/ui/BattleUIManager.cpp
@@ -2,6 +2,7 @@
 #include "BattleManager.hpp"
 #include "BattlePlayerManager.hpp"
 #include "BattlePlayer.hpp"
+#include "PhysicalWorldManager.hpp"
 #include "HolderUI.hpp"
 
 namespace kanji {
@@ -22,6 +23,7 @@ void BattleUIManager::drawImpl() const {
     for (const auto& holder : m_holders) {
         holder.second->draw();
     }
+    m_battle_manager->worldMgr()->drawLegacy();
 }
 
 // private function ------------------------------

--- a/Game/KANJI/src/battle/ui/BattleUIManager.hpp
+++ b/Game/KANJI/src/battle/ui/BattleUIManager.hpp
@@ -1,13 +1,47 @@
 #pragma once
+#include <Siv3D/Camera2D.hpp>
 #include "PlayerId.hpp"
 #include "UIComponent.hpp"
 
 namespace kanji {
 namespace battle {
 class IBattleManager;
+class PhysicalWorldManager;
+class PhysicalMoveManager;
 }
 namespace ui {
 class IHolderUI;
+
+class MoveUIManager : public dx::ui::UIComponent {
+public: // static_const/enum
+public: // static
+public: // public function
+    void update();
+protected: // protected function
+    void drawImpl() const override;
+private: // field
+    const battle::PhysicalMoveManager* const m_move_mgr = nullptr;
+private: // private function
+public: // ctor/dtor
+    MoveUIManager(const battle::PhysicalMoveManager* move_mgr);
+};
+
+
+
+class PhysicalWorldUIManager : public dx::ui::UIComponent {
+public: // static_const/enum
+public: // static
+public: // public function
+    void update();
+protected: // protected function
+    void drawImpl() const override;
+private: // field
+    const battle::PhysicalWorldManager* const m_world_mgr = nullptr;
+private: // private function
+public: // ctor/dtor
+    PhysicalWorldUIManager(const battle::PhysicalWorldManager* world_mgr);
+};
+
 
 class BattleUIManager : public dx::ui::UIComponent {
 public: // static_const/enum
@@ -17,11 +51,14 @@ public: // public function
 protected: // protected function
     void drawImpl() const override;
 private: // field
-    const battle::IBattleManager* const m_battle_manager;
+    s3d::Camera2D m_camera;
+    const battle::IBattleManager* const m_battle_manager = nullptr;
     std::unordered_map<dx::di::PlayerId, std::shared_ptr<IHolderUI>> m_holders;
+    std::shared_ptr<PhysicalWorldUIManager> m_world;
+    std::shared_ptr<MoveUIManager> m_moves;
 private: // private function
 public: // ctor/dtor
-    BattleUIManager(const battle::IBattleManager* battle_manager);
+    BattleUIManager(const battle::IBattleManager* battle_mgr);
 };
 
 

--- a/Game/KANJI/src/masterdata/Move.cpp
+++ b/Game/KANJI/src/masterdata/Move.cpp
@@ -1,0 +1,38 @@
+#include "Move.hpp"
+#include "PhysicalMove.hpp"
+
+namespace kanji {
+namespace md {
+
+/* ---------- MasterRepository ---------- */
+
+// static ----------------------------------------
+// public function -------------------------------
+// private function ------------------------------
+// ctor/dtor -------------------------------------
+MasterRepository::MasterRepository() {
+    // TOdO: デバッグ用
+    std::vector<battle::MomentaryMove> moments;
+    float t = 0.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(20, 0), s3d::Size(60, 60)));
+    t += 2.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(40, 0), s3d::Size(60, 60)));
+    t += 2.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(60, 0), s3d::Size(60, 60)));
+    t += 1.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(60, 0), s3d::Size(60, 60)));
+    t += 7.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(40, 0), s3d::Size(60, 60)));
+    t += 8.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(30, 0), s3d::Size(60, 60)));
+    t += 3.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(10, 0), s3d::Size(60, 60)));
+    t += 2.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center( 0, 0), s3d::Size(60, 60)));
+    const MoveId id = 0;
+    m_masterdata.insert(std::make_pair(id,
+        std::make_shared<Move>(id, U"拳", std::make_shared<battle::Trajectory>(moments))));
+}
+
+}
+}

--- a/Game/KANJI/src/masterdata/Move.cpp
+++ b/Game/KANJI/src/masterdata/Move.cpp
@@ -13,7 +13,7 @@ namespace md {
 MasterRepository::MasterRepository() {
     // TOdO: デバッグ用
     std::vector<battle::MomentaryMove> moments;
-    const s3d::Size size(3, 3);
+    const s3d::Vec2 size(2.5, 2.5);
     float t = 0.f;
     t += 0.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(0.5, 0), size));
     t += 2.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(1.5, 0), size));

--- a/Game/KANJI/src/masterdata/Move.cpp
+++ b/Game/KANJI/src/masterdata/Move.cpp
@@ -13,24 +13,18 @@ namespace md {
 MasterRepository::MasterRepository() {
     // TOdO: デバッグ用
     std::vector<battle::MomentaryMove> moments;
+    const s3d::Size size(3, 3);
     float t = 0.f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(0, 0), s3d::Size(60, 60)));
-    t += 0.1f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(20, 0), s3d::Size(60, 60)));
-    t += 0.2f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(40, 0), s3d::Size(60, 60)));
-    t += 0.2f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(60, 0), s3d::Size(60, 60)));
-    t += 0.1f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(60, 0), s3d::Size(60, 60)));
-    t += 0.7f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(40, 0), s3d::Size(60, 60)));
-    t += 0.8f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(30, 0), s3d::Size(60, 60)));
-    t += 0.3f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(10, 0), s3d::Size(60, 60)));
-    t += 0.2f;
-    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center( 0, 0), s3d::Size(60, 60)));
+    t += 0.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(0.5, 0), size));
+    t += 2.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(1.5, 0), size));
+    t += 2.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(2.5, 0), size));
+    t += 0.5f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(3.5, 0), size));
+    t += 0.5f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(4.0, 0), size));
+    t += 7.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(3.5, 0), size));
+    t += 8.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(2.5, 0), size));
+    t += 3.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(2.0, 0), size));
+    t += 2.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(1.0, 0), size));
+    t += 1.0f / 40.f; moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(0.5, 0), size));
     const MoveId id = 0;
     m_masterdata.insert(std::make_pair(id,
         std::make_shared<Move>(id, U"拳", std::make_shared<battle::Trajectory>(moments))));

--- a/Game/KANJI/src/masterdata/Move.cpp
+++ b/Game/KANJI/src/masterdata/Move.cpp
@@ -14,20 +14,22 @@ MasterRepository::MasterRepository() {
     // TOdO: デバッグ用
     std::vector<battle::MomentaryMove> moments;
     float t = 0.f;
+    moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(0, 0), s3d::Size(60, 60)));
+    t += 0.1f;
     moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(20, 0), s3d::Size(60, 60)));
-    t += 2.f;
+    t += 0.2f;
     moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(40, 0), s3d::Size(60, 60)));
-    t += 2.f;
+    t += 0.2f;
     moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(60, 0), s3d::Size(60, 60)));
-    t += 1.f;
+    t += 0.1f;
     moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(60, 0), s3d::Size(60, 60)));
-    t += 7.f;
+    t += 0.7f;
     moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(40, 0), s3d::Size(60, 60)));
-    t += 8.f;
+    t += 0.8f;
     moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(30, 0), s3d::Size(60, 60)));
-    t += 3.f;
+    t += 0.3f;
     moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center(10, 0), s3d::Size(60, 60)));
-    t += 2.f;
+    t += 0.2f;
     moments.emplace_back(t, 50.f, s3d::Circular(-35, 500), s3d::RectF(s3d::Arg::center( 0, 0), s3d::Size(60, 60)));
     const MoveId id = 0;
     m_masterdata.insert(std::make_pair(id,

--- a/Game/KANJI/src/masterdata/Move.hpp
+++ b/Game/KANJI/src/masterdata/Move.hpp
@@ -1,0 +1,49 @@
+#pragma once
+#include <unordered_map>
+#include <Siv3D/String.hpp>
+#include "Singleton.hpp"
+
+namespace kanji {
+namespace battle {
+class Trajectory;
+}
+namespace md {
+
+// TOdO:
+using MoveId = int;
+
+class Move {
+public: // static_const/enum
+public: // static
+public: // public function
+public: // field
+    const MoveId id;
+    const s3d::String kanji;
+    const std::shared_ptr<battle::Trajectory> trajectory;
+private: // private function
+public: // ctor/dtor
+    Move(MoveId id, const s3d::String& kanji, const std::shared_ptr<battle::Trajectory>& trajectory) :
+        id(id), kanji(kanji), trajectory(trajectory) {}
+};
+
+// TOdO: Template化
+class MasterRepository : public dx::cmp::Singleton<MasterRepository> {
+public: // static_const/enum
+    using Id = MoveId;
+    using Value = Move;
+public: // static
+public: // public function
+    const std::shared_ptr<Value>& get(Id id) {
+        return m_masterdata.at(id);
+    }
+private: // field
+    std::unordered_map<Id, std::shared_ptr<Value>> m_masterdata;
+private: // private function
+public: // ctor/dtor
+    MasterRepository();
+};
+
+
+
+}
+}

--- a/Game/KANJI/src/scene/main/BattleScene.cpp
+++ b/Game/KANJI/src/scene/main/BattleScene.cpp
@@ -100,99 +100,16 @@ void BattleScene::update() {
     updateLegacy();
     m_ui->update();
 }
-void BattleScene::updateLegacy() {
-    // ↓ここから下は試し書きの無法地帯
-    // 物理演算の精度
-    static constexpr int32 velocityIterations = 12;
-    static constexpr int32 positionIterations = 4;
-    
-    // (y > 10) まで落下した P2Body は削除
-    m_bodies.remove_if([](const P2Body& body) { return body.getPos().y > 10; });
-
-    // 物理演算のワールドを更新
-    m_world.update(true ? (1.0 / 60.0) : Scene::DeltaTime(), velocityIterations, positionIterations);
-        
-
-    m_camera.update();
-    {
-        // 2D カメラの設定から Transformer2D を作成・適用
-        const auto t = m_camera.createTransformer();
-        
-        if (MouseL.down()) {
-            // クリックした場所にボールを作成
-            m_bodies << m_world.createCircle(Cursor::PosF(), 0.5);
-        }
-        const auto& input = dx::di::Input::get(dx::di::GamePadId::_1P);
-        s3d::Vec2 velocity(
-            param->force_horizontal * input.arrowL().x,
-            input.dpad().up().down() || input.buttons().b().down() ? -param->force_jump : 0.0);
-        // m_chara.applyForce(force);
-        const auto& v = m_chara.getVelocity();
-        if (dx::misc::approximatelyZero(velocity)) {
-            velocity.x = v.x * param->air_resistance;
-            velocity.y = v.y;
-        }
-        else {
-            if (dx::misc::approximatelyZero(velocity.x)) {
-                velocity.x = v.x;
-            }
-            if (dx::misc::approximatelyZero(velocity.y)) {
-                velocity.y = v.y;
-            }
-            velocity.x *= param->air_resistance;
-        }
-        m_chara.setVelocity(velocity);
-    }
-}
+void BattleScene::updateLegacy() {}
 void BattleScene::draw() const {
     m_ui->draw();
     drawLegacy();
 }
-void BattleScene::drawLegacy() const {
-    // ↓ここから下は試し書きの無法地帯
-    {
-        // 2D カメラの設定から Transformer2D を作成・適用
-        const auto t = m_camera.createTransformer();
-        
-        // 床を描画
-        m_floor.draw(Palette::Skyblue);
-        m_ceiling.draw(Palette::Skyblue);
-        m_wall_left.draw(Palette::Skyblue);
-        m_wall_right.draw(Palette::Skyblue);
-        
-        // 物体を描画
-        for (const auto& body : m_bodies) {
-            body.draw(HSV(body.id() * 10, 0.7, 0.9));
-        }
-        m_chara.draw();
-    }
-    m_camera.draw();
-}
+void BattleScene::drawLegacy() const {}
 
 // private function ------------------------------
 // ctor/dtor -------------------------------------
-BattleScene::BattleScene(const InitData& init) :
-    IScene(init),
-    // ↓ここから下は試し書きの無法地帯
-    param(dx::cmp::HotReloadManager::createParams<param::CharaPhysics>()),
-    m_start(
-        Rect(Arg::center = Scene::Center().movedBy(65, 170), 300, 60), DrawableText(FontAsset(U"Menu"), U"はじめる"),
-        Transition(0.4s, 0.2s)),
-    m_camera(Vec2(0, -8), 20.0, s3d::Camera2DParameters::MouseOnly()),
-    m_world(9.8),
-    m_chara     (m_world.createRect      (Vec2(  0, -5), SizeF(2, 3),         P2Material(1.0, 0.0, param->chara_friction))),
-    m_floor     (m_world.createStaticLine(Vec2(  0,  0), Line(-25, 0, 25, 0), P2Material(1.0, 0.0, param->floor_friction))),
-    m_ceiling   (m_world.createStaticLine(Vec2(  0,-25), Line(-25, 0, 25, 0), P2Material(1.0, 0.0, param->ceiling_friction))),
-    m_wall_left (m_world.createStaticLine(Vec2(-25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction))),
-    m_wall_right(m_world.createStaticLine(Vec2( 25,  0), Line(0, -25, 0, 10), P2Material(1.0, 0.0, param->wall_friction)))
-{
-    m_chara.setFixedRotation(true);
-    // 物理演算のワールド更新に 60FPS の定数時間を使う場合は true, 実時間を使う場合 false
-    constexpr bool useConstantDeltaTime = true;
-    if (useConstantDeltaTime) { // フレームレート上限を 60 FPS に
-        Graphics::SetTargetFrameRateHz(60);
-    }
-
+BattleScene::BattleScene(const InitData& init) : IScene(init) {
     initialize();
 }
 

--- a/Game/KANJI/src/scene/main/BattleScene.hpp
+++ b/Game/KANJI/src/scene/main/BattleScene.hpp
@@ -2,7 +2,6 @@
 
 #include "SceneState.hpp"
 #include "UIComponent.hpp"
-#include "CharaPhysicsParameters.hpp"
 
 namespace kanji {
 namespace battle {
@@ -14,7 +13,6 @@ namespace ui {
 namespace seq {
 
 
-// タイトルシーン
 class BattleScene : public KanjiScene {
 public: // static_const/enum
 public: // static
@@ -27,23 +25,6 @@ public: // public function
 private: // field
     std::shared_ptr<battle::IBattleManager> m_mgr;
     std::shared_ptr<ui::BattleUIManager> m_ui;
-    // ↓ここから下は試し書きの無法地帯
-    std::shared_ptr<param::CharaPhysics> param;
-    std::pair<s3d::DrawableText, s3d::DrawableText> m_title;
-    dui::Button m_start;
-    
-    // 2Dカメラ
-    Camera2D m_camera;
-    // 物理演算用のワールド
-    P2World m_world;
-    // 物体
-    P2Body m_chara;
-    Array<P2Body> m_bodies;
-    // 床
-    const P2Body m_floor;
-    const P2Body m_ceiling;
-    const P2Body m_wall_left;
-    const P2Body m_wall_right;
 private: // private function
 public: // ctor/dtor
     BattleScene(const InitData& init);


### PR DESCRIPTION
BattleScene内に書いてあった処理をBattleManager/BattleUIManager等に移動
- キャラクタ→PhysicalCharacter
- 壁/床→PhysicalStage
- 各種描画処理→XXXUIManager

技定義
- md::Move: マスタデータ (被弾時のdamage、ふっとばし力、当たり判定、軌道など)
- PhysicalMove: 実際に発動された技
- MomentaryMove: 発動中のPhysicalMoveのある時刻tにおける情報
- PhysicalMoveManager: 現在絶賛発動中の技を保持、毎frame一括で更新する